### PR TITLE
feat/activations: add in-place activations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 collenchyma = { version = "0.0.8", default-features = false }
 collenchyma-blas = { version = "0.2.0", default-features = false }
-collenchyma-nn = { version = "0.3.0", default-features = false }
+collenchyma-nn = { version = "0.3.1", default-features = false }
 
 log = "0.3.2"
 rand = "0.3.0"

--- a/examples/benchmarks.rs
+++ b/examples/benchmarks.rs
@@ -10,11 +10,27 @@ use leaf::layers::*;
 use leaf::layer::*;
 use leaf::network::*;
 use std::rc::Rc;
+use std::env;
 
 fn main() {
-    // bench_mnsit_forward();
-    bench_alexnet();
-    bench_overfeat();
+    let nets: Vec<String> = vec!("alexnet".to_string(), "overfeat".to_string(), "vgg".to_string());
+    if let Some(net) = env::args().nth(1) {
+        if nets.contains(&net) {
+            println!("Executing Model: {:?}", net);
+            if net == "alexnet".to_string() {
+                bench_alexnet();
+            } else if net == "overfeat".to_string() {
+                bench_overfeat();
+            } else if net == "vgg".to_string() {
+                bench_vgg_a();
+            }
+        } else {
+            println!("Sorry, no model found with name '{:?}'. Valid options: {:?}", net, nets);
+        }
+    } else {
+        println!("No `net` argument specified. Default: `alexnet`. Valid options: {:?}", nets);
+        bench_alexnet();
+    }
 }
 
 #[cfg(feature = "native")]
@@ -94,54 +110,6 @@ fn get_time_scale<'a>(sec: f64) -> (f64, &'a str) {
     }
 }
 
-
-// #[bench]
-#[allow(dead_code)]
-#[cfg(feature = "cuda")]
-fn bench_mnsit_forward() {
-    let mut cfg = NetworkConfig::default();
-    // set up input
-    cfg.add_input("in", &vec![1, 30, 30]);
-    cfg.add_input("label", &vec![1, 1, 10]);
-    // set up sigmoid
-    let mut sig_cfg = LayerConfig::new("sig", LayerType::Sigmoid);
-    sig_cfg.add_input("in");
-    sig_cfg.add_output("sig_out");
-    cfg.add_layer(sig_cfg);
-
-    let fc_layer_cfg = LinearConfig {
-        output_size: 10,
-    };
-    let mut fc_cfg = LayerConfig::new("fully_connected", LayerType::Linear(fc_layer_cfg));
-    fc_cfg.add_input("sig_out");
-    fc_cfg.add_output("fc_out");
-    cfg.add_layer(fc_cfg);
-    // // set up softmax_loss
-    // let mut loss_cfg = LayerConfig::new("loss", LayerType::SoftmaxLoss);
-    // loss_cfg.add_input("fc_out");
-    // loss_cfg.add_input("label");
-    // cfg.add_layer(loss_cfg);
-
-    let backend = cuda_backend();
-    let native_backend = native_backend();
-    let mut network = Network::from_config(backend.clone(), &cfg);
-    let loss = &mut 0f32;
-
-    let func = || {
-        let forward_time = timeit_loops!(1, {
-            let inp = SharedTensor::<f32>::new(backend.device(), &vec![1, 30, 30]).unwrap();
-            let label = SharedTensor::<f32>::new(native_backend.device(), &vec![1, 1, 10]).unwrap();
-
-            let inp_lock = Arc::new(RwLock::new(inp));
-            let label_lock = Arc::new(RwLock::new(label));
-
-            network.forward(&[inp_lock, label_lock], loss);
-        });
-        println!("Forward step: {}", scale_time(forward_time, "ms"));
-    };
-    { bench_profile("mnist_forward", func, 10); }
-}
-
 #[cfg(not(feature = "cuda"))]
 fn bench_alexnet() {}
 #[cfg(feature = "cuda")]
@@ -164,7 +132,7 @@ fn bench_alexnet() {
     // Layer: conv1/relu
     let mut conv1_relu_cfg = LayerConfig::new("conv1/relu", LayerType::ReLU);
     conv1_relu_cfg.add_input("conv1_preac");
-    conv1_relu_cfg.add_output("conv1_out");
+    conv1_relu_cfg.add_output("conv1_preac");
     cfg.add_layer(conv1_relu_cfg);
     // Layer: pool1
     let pool1_layer_cfg = PoolingConfig {
@@ -174,7 +142,7 @@ fn bench_alexnet() {
         padding: vec![0], // TODO: make optional
     };
     let mut pool1_cfg = LayerConfig::new("pool1", LayerType::Pooling(pool1_layer_cfg));
-    pool1_cfg.add_input("conv1_out");
+    pool1_cfg.add_input("conv1_preac");
     pool1_cfg.add_output("pool1_out");
     cfg.add_layer(pool1_cfg);
     // Layer: conv2
@@ -192,7 +160,7 @@ fn bench_alexnet() {
     // Layer: conv2/relu
     let mut conv2_relu_cfg = LayerConfig::new("conv2/relu", LayerType::ReLU);
     conv2_relu_cfg.add_input("conv2_preac");
-    conv2_relu_cfg.add_output("conv2_out");
+    conv2_relu_cfg.add_output("conv2_preac");
     cfg.add_layer(conv2_relu_cfg);
     // Layer: pool2
     let pool2_layer_cfg = PoolingConfig {
@@ -202,7 +170,7 @@ fn bench_alexnet() {
         padding: vec![0], // TODO: make optional
     };
     let mut pool2_cfg = LayerConfig::new("pool2", LayerType::Pooling(pool2_layer_cfg));
-    pool2_cfg.add_input("conv2_out");
+    pool2_cfg.add_input("conv2_preac");
     pool2_cfg.add_output("pool2_out");
     cfg.add_layer(pool2_cfg);
     // Layer: conv3
@@ -220,7 +188,7 @@ fn bench_alexnet() {
     // Layer: conv3/relu
     let mut conv3_relu_cfg = LayerConfig::new("conv3/relu", LayerType::ReLU);
     conv3_relu_cfg.add_input("conv3_preac");
-    conv3_relu_cfg.add_output("conv3_out");
+    conv3_relu_cfg.add_output("conv3_preac");
     cfg.add_layer(conv3_relu_cfg);
     // Layer: conv4
     let conv4_layer_cfg = ConvolutionConfig {
@@ -231,13 +199,13 @@ fn bench_alexnet() {
         axis: None
     };
     let mut conv4_cfg = LayerConfig::new("conv4", LayerType::Convolution(conv4_layer_cfg));
-    conv4_cfg.add_input("conv3_out");
+    conv4_cfg.add_input("conv3_preac");
     conv4_cfg.add_output("conv4_preac");
     cfg.add_layer(conv4_cfg);
     // Layer: conv4/relu
     let mut conv4_relu_cfg = LayerConfig::new("conv4/relu", LayerType::ReLU);
     conv4_relu_cfg.add_input("conv4_preac");
-    conv4_relu_cfg.add_output("conv4_out");
+    conv4_relu_cfg.add_output("conv4_preac");
     cfg.add_layer(conv4_relu_cfg);
     // Layer: conv5
     let conv5_layer_cfg = ConvolutionConfig {
@@ -248,13 +216,13 @@ fn bench_alexnet() {
         axis: None
     };
     let mut conv5_cfg = LayerConfig::new("conv5", LayerType::Convolution(conv5_layer_cfg));
-    conv5_cfg.add_input("conv4_out");
+    conv5_cfg.add_input("conv4_preac");
     conv5_cfg.add_output("conv5_preac");
     cfg.add_layer(conv5_cfg);
     // Layer: conv5/relu
     let mut conv5_relu_cfg = LayerConfig::new("conv5/relu", LayerType::ReLU);
     conv5_relu_cfg.add_input("conv5_preac");
-    conv5_relu_cfg.add_output("conv5_out");
+    conv5_relu_cfg.add_output("conv5_preac");
     cfg.add_layer(conv5_relu_cfg);
     // Layer: pool3
     let pool3_layer_cfg = PoolingConfig {
@@ -264,7 +232,7 @@ fn bench_alexnet() {
         padding: vec![0], // TODO: make optional
     };
     let mut pool3_cfg = LayerConfig::new("pool3", LayerType::Pooling(pool3_layer_cfg));
-    pool3_cfg.add_input("conv5_out");
+    pool3_cfg.add_input("conv5_preac");
     pool3_cfg.add_output("pool3_out");
     cfg.add_layer(pool3_cfg);
     // Layer: fc1
@@ -336,7 +304,9 @@ fn bench_alexnet() {
 }
 
 #[cfg(not(feature = "cuda"))]
-fn bench_overfeat() {}
+fn bench_overfeat() {
+    println!("Examples run only with CUDA support at the moment, because of missing native convolution implementation for the Collenchyma NN Plugin.");
+}
 #[cfg(feature = "cuda")]
 fn bench_overfeat() {
     let mut cfg = NetworkConfig::default();
@@ -357,7 +327,7 @@ fn bench_overfeat() {
     // Layer: conv1/relu
     let mut conv1_relu_cfg = LayerConfig::new("conv1/relu", LayerType::ReLU);
     conv1_relu_cfg.add_input("conv1_preac");
-    conv1_relu_cfg.add_output("conv1_out");
+    conv1_relu_cfg.add_output("conv1_preac");
     cfg.add_layer(conv1_relu_cfg);
     // Layer: pool1
     let pool1_layer_cfg = PoolingConfig {
@@ -367,7 +337,7 @@ fn bench_overfeat() {
         padding: vec![0], // TODO: make optional
     };
     let mut pool1_cfg = LayerConfig::new("pool1", LayerType::Pooling(pool1_layer_cfg));
-    pool1_cfg.add_input("conv1_out");
+    pool1_cfg.add_input("conv1_preac");
     pool1_cfg.add_output("pool1_out");
     cfg.add_layer(pool1_cfg);
     // Layer: conv2
@@ -385,7 +355,7 @@ fn bench_overfeat() {
     // Layer: conv2/relu
     let mut conv2_relu_cfg = LayerConfig::new("conv2/relu", LayerType::ReLU);
     conv2_relu_cfg.add_input("conv2_preac");
-    conv2_relu_cfg.add_output("conv2_out");
+    conv2_relu_cfg.add_output("conv2_preac");
     cfg.add_layer(conv2_relu_cfg);
     // Layer: pool2
     let pool2_layer_cfg = PoolingConfig {
@@ -395,7 +365,7 @@ fn bench_overfeat() {
         padding: vec![0], // TODO: make optional
     };
     let mut pool2_cfg = LayerConfig::new("pool2", LayerType::Pooling(pool2_layer_cfg));
-    pool2_cfg.add_input("conv2_out");
+    pool2_cfg.add_input("conv2_preac");
     pool2_cfg.add_output("pool2_out");
     cfg.add_layer(pool2_cfg);
     // Layer: conv3
@@ -413,7 +383,7 @@ fn bench_overfeat() {
     // Layer: conv3/relu
     let mut conv3_relu_cfg = LayerConfig::new("conv3/relu", LayerType::ReLU);
     conv3_relu_cfg.add_input("conv3_preac");
-    conv3_relu_cfg.add_output("conv3_out");
+    conv3_relu_cfg.add_output("conv3_preac");
     cfg.add_layer(conv3_relu_cfg);
     // Layer: conv4
     let conv4_layer_cfg = ConvolutionConfig {
@@ -424,13 +394,13 @@ fn bench_overfeat() {
         axis: None
     };
     let mut conv4_cfg = LayerConfig::new("conv4", LayerType::Convolution(conv4_layer_cfg));
-    conv4_cfg.add_input("conv3_out");
+    conv4_cfg.add_input("conv3_preac");
     conv4_cfg.add_output("conv4_preac");
     cfg.add_layer(conv4_cfg);
     // Layer: conv4/relu
     let mut conv4_relu_cfg = LayerConfig::new("conv4/relu", LayerType::ReLU);
     conv4_relu_cfg.add_input("conv4_preac");
-    conv4_relu_cfg.add_output("conv4_out");
+    conv4_relu_cfg.add_output("conv4_preac");
     cfg.add_layer(conv4_relu_cfg);
     // Layer: conv5
     let conv5_layer_cfg = ConvolutionConfig {
@@ -441,13 +411,13 @@ fn bench_overfeat() {
         axis: None
     };
     let mut conv5_cfg = LayerConfig::new("conv5", LayerType::Convolution(conv5_layer_cfg));
-    conv5_cfg.add_input("conv4_out");
+    conv5_cfg.add_input("conv4_preac");
     conv5_cfg.add_output("conv5_preac");
     cfg.add_layer(conv5_cfg);
     // Layer: conv5/relu
     let mut conv5_relu_cfg = LayerConfig::new("conv5/relu", LayerType::ReLU);
     conv5_relu_cfg.add_input("conv5_preac");
-    conv5_relu_cfg.add_output("conv5_out");
+    conv5_relu_cfg.add_output("conv5_preac");
     cfg.add_layer(conv5_relu_cfg);
     // Layer: pool5
     let pool5_layer_cfg = PoolingConfig {
@@ -457,7 +427,7 @@ fn bench_overfeat() {
         padding: vec![0], // TODO: make optional
     };
     let mut pool5_cfg = LayerConfig::new("pool5", LayerType::Pooling(pool5_layer_cfg));
-    pool5_cfg.add_input("conv5_out");
+    pool5_cfg.add_input("conv5_preac");
     pool5_cfg.add_output("pool5_out");
     cfg.add_layer(pool5_cfg);
     // Layer: fc1
@@ -495,6 +465,274 @@ fn bench_overfeat() {
                 {
                     let loss = &mut 0f32;
                     let inp = SharedTensor::<f32>::new(backend.device(), &vec![128, 3, 231, 231]).unwrap();
+
+                    let inp_lock = Arc::new(RwLock::new(inp));
+                    network.forward(&[inp_lock.clone()], loss);
+                }
+            });
+            println!("Forward step: {}", scale_time(forward_time, "ms"));
+        };
+        { bench_profile("overfeat_forward", func, 10); }
+    }
+    {
+        let func = || {
+            let backward_time = timeit_loops!(1, {
+                {
+                    network.backward_input();
+                }
+            });
+            println!("backward input step: {}", scale_time(backward_time, "ms"));
+        };
+        { bench_profile("overfeat_backward_input", func, 10); }
+    }
+    {
+        let func = || {
+            let backward_time = timeit_loops!(1, {
+                {
+                    network.backward_parameters();
+                }
+            });
+            println!("backward parameters step: {}", scale_time(backward_time, "ms"));
+        };
+        { bench_profile("overfeat_backward_parameters", func, 10); }
+    }
+}
+
+#[cfg(not(feature = "cuda"))]
+fn bench_vgg_a() {
+    println!("Examples run only with CUDA support at the moment, because of missing native convolution implementation for the Collenchyma NN Plugin.");
+}
+#[cfg(feature = "cuda")]
+fn bench_vgg_a() {
+    let mut cfg = NetworkConfig::default();
+    // Layer: data
+    cfg.add_input("data", &vec![64, 3, 224, 224]);
+    // Layer: conv1
+    let conv1_layer_cfg = ConvolutionConfig {
+        num_output: 64,
+        filter_shape: vec![3],
+        padding: vec![1],
+        stride: vec![1],
+        axis: None
+    };
+    let mut conv1_cfg = LayerConfig::new("conv1", LayerType::Convolution(conv1_layer_cfg));
+    conv1_cfg.add_input("data");
+    conv1_cfg.add_output("conv1_preac");
+    cfg.add_layer(conv1_cfg);
+    // Layer: conv1/relu
+    let mut conv1_relu_cfg = LayerConfig::new("conv1/relu", LayerType::ReLU);
+    conv1_relu_cfg.add_input("conv1_preac");
+    conv1_relu_cfg.add_output("conv1_preac");
+    cfg.add_layer(conv1_relu_cfg);
+    // Layer: pool1
+    let pool1_layer_cfg = PoolingConfig {
+        mode: PoolingMode::Max,
+        filter_shape: vec![2],
+        stride: vec![2],
+        padding: vec![0], // TODO: make optional
+    };
+    let mut pool1_cfg = LayerConfig::new("pool1", LayerType::Pooling(pool1_layer_cfg));
+    pool1_cfg.add_input("conv1_preac");
+    pool1_cfg.add_output("pool1_out");
+    cfg.add_layer(pool1_cfg);
+    // Layer: conv2
+    let conv2_layer_cfg = ConvolutionConfig {
+        num_output: 128,
+        filter_shape: vec![3],
+        padding: vec![1],
+        stride: vec![1],
+        axis: None
+    };
+    let mut conv2_cfg = LayerConfig::new("conv2", LayerType::Convolution(conv2_layer_cfg));
+    conv2_cfg.add_input("pool1_out");
+    conv2_cfg.add_output("conv2_preac");
+    cfg.add_layer(conv2_cfg);
+    // Layer: conv2/relu
+    let mut conv2_relu_cfg = LayerConfig::new("conv2/relu", LayerType::ReLU);
+    conv2_relu_cfg.add_input("conv2_preac");
+    conv2_relu_cfg.add_output("conv2_preac");
+    cfg.add_layer(conv2_relu_cfg);
+    // Layer: pool2
+    let pool2_layer_cfg = PoolingConfig {
+        mode: PoolingMode::Max,
+        filter_shape: vec![2],
+        stride: vec![2],
+        padding: vec![0], // TODO: make optional
+    };
+    let mut pool2_cfg = LayerConfig::new("pool2", LayerType::Pooling(pool2_layer_cfg));
+    pool2_cfg.add_input("conv2_preac");
+    pool2_cfg.add_output("pool2_out");
+    cfg.add_layer(pool2_cfg);
+    // Layer: conv3
+    let conv3_layer_cfg = ConvolutionConfig {
+        num_output: 256,
+        filter_shape: vec![3],
+        padding: vec![1],
+        stride: vec![1],
+        axis: None
+    };
+    let mut conv3_cfg = LayerConfig::new("conv3", LayerType::Convolution(conv3_layer_cfg));
+    conv3_cfg.add_input("pool2_out");
+    conv3_cfg.add_output("conv3_preac");
+    cfg.add_layer(conv3_cfg);
+    // Layer: conv3/relu
+    let mut conv3_relu_cfg = LayerConfig::new("conv3/relu", LayerType::ReLU);
+    conv3_relu_cfg.add_input("conv3_preac");
+    conv3_relu_cfg.add_output("conv3_preac");
+    cfg.add_layer(conv3_relu_cfg);
+    // Layer: conv4
+    let conv4_layer_cfg = ConvolutionConfig {
+        num_output: 256,
+        filter_shape: vec![3],
+        padding: vec![1],
+        stride: vec![1],
+        axis: None
+    };
+    let mut conv4_cfg = LayerConfig::new("conv4", LayerType::Convolution(conv4_layer_cfg));
+    conv4_cfg.add_input("conv3_preac");
+    conv4_cfg.add_output("conv4_preac");
+    cfg.add_layer(conv4_cfg);
+    // Layer: conv4/relu
+    let mut conv4_relu_cfg = LayerConfig::new("conv4/relu", LayerType::ReLU);
+    conv4_relu_cfg.add_input("conv4_preac");
+    conv4_relu_cfg.add_output("conv4_out");
+    cfg.add_layer(conv4_relu_cfg);
+    // Layer: pool3 for conv4
+    let pool3_layer_cfg = PoolingConfig {
+        mode: PoolingMode::Max,
+        filter_shape: vec![2],
+        stride: vec![2],
+        padding: vec![0], // TODO: make optional
+    };
+    let mut pool3_cfg = LayerConfig::new("pool3", LayerType::Pooling(pool3_layer_cfg));
+    pool3_cfg.add_input("conv4_out");
+    pool3_cfg.add_output("pool3_out");
+    cfg.add_layer(pool3_cfg);
+    // Layer: conv5
+    let conv5_layer_cfg = ConvolutionConfig {
+        num_output: 512,
+        filter_shape: vec![3],
+        padding: vec![1],
+        stride: vec![1],
+        axis: None
+    };
+    let mut conv5_cfg = LayerConfig::new("conv5", LayerType::Convolution(conv5_layer_cfg));
+    conv5_cfg.add_input("conv4_out");
+    conv5_cfg.add_output("conv5_preac");
+    cfg.add_layer(conv5_cfg);
+    // Layer: conv5/relu
+    let mut conv5_relu_cfg = LayerConfig::new("conv5/relu", LayerType::ReLU);
+    conv5_relu_cfg.add_input("conv5_preac");
+    conv5_relu_cfg.add_output("conv5_preac");
+    cfg.add_layer(conv5_relu_cfg);
+    // Layer: conv6
+    let conv6_layer_cfg = ConvolutionConfig {
+        num_output: 512,
+        filter_shape: vec![3],
+        padding: vec![1],
+        stride: vec![1],
+        axis: None
+    };
+    let mut conv6_cfg = LayerConfig::new("conv6", LayerType::Convolution(conv6_layer_cfg));
+    conv6_cfg.add_input("conv5_preac");
+    conv6_cfg.add_output("conv6_preac");
+    cfg.add_layer(conv6_cfg);
+    // Layer: conv6/relu
+    let mut conv6_relu_cfg = LayerConfig::new("conv6/relu", LayerType::ReLU);
+    conv6_relu_cfg.add_input("conv6_preac");
+    conv6_relu_cfg.add_output("conv6_preac");
+    cfg.add_layer(conv6_relu_cfg);
+    // Layer: pool4 for conv6
+    let pool4_layer_cfg = PoolingConfig {
+        mode: PoolingMode::Max,
+        filter_shape: vec![2],
+        stride: vec![2],
+        padding: vec![0], // TODO: make optional
+    };
+    let mut pool4_cfg = LayerConfig::new("pool4", LayerType::Pooling(pool4_layer_cfg));
+    pool4_cfg.add_input("conv6_preac");
+    pool4_cfg.add_output("pool4_out");
+    cfg.add_layer(pool4_cfg);
+    // Layer:conv7
+    let conv7_layer_cfg = ConvolutionConfig {
+        num_output: 512,
+        filter_shape: vec![3],
+        padding: vec![1],
+        stride: vec![1],
+        axis: None
+    };
+    let mut conv7_cfg = LayerConfig::new("conv7", LayerType::Convolution(conv7_layer_cfg));
+    conv7_cfg.add_input("pool4_out");
+    conv7_cfg.add_output("conv7_preac");
+    cfg.add_layer(conv7_cfg);
+    // Layer: conv7/relu
+    let mut conv7_relu_cfg = LayerConfig::new("conv7/relu", LayerType::ReLU);
+    conv7_relu_cfg.add_input("conv7_preac");
+    conv7_relu_cfg.add_output("conv7_preac");
+    cfg.add_layer(conv7_relu_cfg);
+    // Layer:conv8
+    let conv8_layer_cfg = ConvolutionConfig {
+        num_output: 512,
+        filter_shape: vec![3],
+        padding: vec![1],
+        stride: vec![1],
+        axis: None
+    };
+    let mut conv8_cfg = LayerConfig::new("conv8", LayerType::Convolution(conv8_layer_cfg));
+    conv8_cfg.add_input("conv7_preac");
+    conv8_cfg.add_output("conv8_preac");
+    cfg.add_layer(conv8_cfg);
+    // Layer: conv8/relu
+    let mut conv8_relu_cfg = LayerConfig::new("conv8/relu", LayerType::ReLU);
+    conv8_relu_cfg.add_input("conv8_preac");
+    conv8_relu_cfg.add_output("conv8_preac");
+    cfg.add_layer(conv8_relu_cfg);
+    // Layer: pool5 for conv8
+    let pool5_layer_cfg = PoolingConfig {
+        mode: PoolingMode::Max,
+        filter_shape: vec![2],
+        stride: vec![2],
+        padding: vec![0], // TODO: make optional
+    };
+    let mut pool5_cfg = LayerConfig::new("pool5", LayerType::Pooling(pool5_layer_cfg));
+    pool5_cfg.add_input("conv8_preac");
+    pool5_cfg.add_output("pool5_out");
+    cfg.add_layer(pool5_cfg);
+    // Layer: fc1
+    let fc1_layer_cfg = LinearConfig {
+        output_size: 4096,
+    };
+    let mut fc1_cfg = LayerConfig::new("fc1", LayerType::Linear(fc1_layer_cfg));
+    fc1_cfg.add_input("pool5_out");
+    fc1_cfg.add_output("fc1_out");
+    cfg.add_layer(fc1_cfg);
+    // Layer: fc2
+    let fc2_layer_cfg = LinearConfig {
+        output_size: 4096,
+    };
+    let mut fc2_cfg = LayerConfig::new("fc2", LayerType::Linear(fc2_layer_cfg));
+    fc2_cfg.add_input("fc1_out");
+    fc2_cfg.add_output("fc2_out");
+    cfg.add_layer(fc2_cfg);
+    // Layer: fc3
+    let fc3_layer_cfg = LinearConfig {
+        output_size: 1000,
+    };
+    let mut fc3_cfg = LayerConfig::new("fc3", LayerType::Linear(fc3_layer_cfg));
+    fc3_cfg.add_input("fc2_out");
+    fc3_cfg.add_output("fc3_out");
+    cfg.add_layer(fc3_cfg);
+
+    let backend = cuda_backend();
+    // let native_backend = native_backend();
+    let mut network = Network::from_config(backend.clone(), &cfg);
+
+    {
+        let func = || {
+            let forward_time = timeit_loops!(1, {
+                {
+                    let loss = &mut 0f32;
+                    let inp = SharedTensor::<f32>::new(backend.device(), &vec![64, 3, 224, 224]).unwrap();
 
                     let inp_lock = Arc::new(RwLock::new(inp));
                     network.forward(&[inp_lock.clone()], loss);

--- a/src/layers/activation/mod.rs
+++ b/src/layers/activation/mod.rs
@@ -13,10 +13,14 @@
 //! as [Sigmoid][mod_sigmoid], TanH, [ReLU][mod_relu] should be used. In most cases ReLU might
 //! provide the best results.
 //!
+//! If you supply the same blob as input and output to a layer via the [LayerConfig][struct_layerconfig],
+//! computations will be done in-place, requiring less memory.
+//!
 //! The activation function is also sometimes called transfer function.
 //!
 //! [mod_sigmoid]: ./sigmoid/index.html
 //! [mod_relu]: ./relu/index.html
+//! [struct_layerconfig]: ../../layer/struct.LayerConfig.html
 #[macro_export]
 macro_rules! impl_ilayer_activation {
     () => (

--- a/src/layers/activation/relu.rs
+++ b/src/layers/activation/relu.rs
@@ -7,7 +7,7 @@
 //! needed in a Sigmoid layer.
 
 use co::{IBackend,SharedTensor};
-use conn::Relu;
+use conn::{Relu, ReluPointwise};
 use layer::*;
 use util::ArcLock;
 
@@ -16,8 +16,12 @@ use util::ArcLock;
 /// ReLU Activation Layer
 pub struct ReLU;
 
-impl<B: IBackend + Relu<f32>> ILayer<B> for ReLU {
+impl<B: IBackend + Relu<f32> + ReluPointwise<f32>> ILayer<B> for ReLU {
     impl_ilayer_activation!();
+
+    fn compute_in_place(&self) -> bool {
+        true
+    }
 
     fn reshape(&mut self,
                backend: ::std::rc::Rc<B>,
@@ -27,24 +31,30 @@ impl<B: IBackend + Relu<f32>> ILayer<B> for ReLU {
                weights_gradient: &mut Vec<ArcLock<SharedTensor<f32>>>,
                output_data: &mut Vec<ArcLock<SharedTensor<f32>>>,
                output_gradient: &mut Vec<ArcLock<SharedTensor<f32>>>) {
-        let inp = input_data[0].read().unwrap();
-        input_gradient[0].write().unwrap().resize(inp.desc()).unwrap();
-        output_data[0].write().unwrap().resize(inp.desc()).unwrap();
-        output_gradient[0].write().unwrap().resize(inp.desc()).unwrap();
+        if let Some(inp) = input_data.get(0) {
+            let read_inp = inp.read().unwrap();
+            let input_desc = read_inp.desc();
+            input_gradient[0].write().unwrap().resize(input_desc).unwrap();
+            output_data[0].write().unwrap().resize(input_desc).unwrap();
+            output_gradient[0].write().unwrap().resize(input_desc).unwrap();
+        }
     }
 }
 
-impl<B: IBackend + Relu<f32>> ComputeOutput<f32, B> for ReLU {
+impl<B: IBackend + Relu<f32> + ReluPointwise<f32>> ComputeOutput<f32, B> for ReLU {
     fn compute_output(&self,
                       backend: &B,
                       _weights: &[&SharedTensor<f32>],
                       input_data: &[&SharedTensor<f32>],
                       output_data: &mut [&mut SharedTensor<f32>]) {
-        backend.relu_plain(input_data[0], output_data[0]).unwrap();
+        match input_data.get(0) {
+            Some(input) => backend.relu_plain(input, output_data[0]).unwrap(),
+            None => backend.relu_pointwise_plain(output_data[0]).unwrap(),
+        }
     }
 }
 
-impl<B: IBackend + Relu<f32>> ComputeInputGradient<f32, B> for ReLU {
+impl<B: IBackend + Relu<f32> + ReluPointwise<f32>> ComputeInputGradient<f32, B> for ReLU {
     fn compute_input_gradient(&self,
                               backend: &B,
                               weights_data: &[&SharedTensor<f32>],
@@ -52,8 +62,11 @@ impl<B: IBackend + Relu<f32>> ComputeInputGradient<f32, B> for ReLU {
                               output_gradients: &[&SharedTensor<f32>],
                               input_data: &[&SharedTensor<f32>],
                               input_gradients: &mut [&mut SharedTensor<f32>]) {
-        backend.relu_grad_plain(output_data[0], output_gradients[0], input_data[0], input_gradients[0]).unwrap();
+        match output_data.get(0) {
+            Some(_) => backend.relu_grad_plain(output_data[0], output_gradients[0], input_data[0], input_gradients[0]).unwrap(),
+            None => backend.relu_pointwise_grad_plain(input_data[0], input_gradients[0]).unwrap(),
+        }
     }
 }
 
-impl<B: IBackend + Relu<f32>> ComputeParametersGradient<f32, B> for ReLU {}
+impl<B: IBackend + Relu<f32> + ReluPointwise<f32>> ComputeParametersGradient<f32, B> for ReLU {}

--- a/src/layers/activation/sigmoid.rs
+++ b/src/layers/activation/sigmoid.rs
@@ -22,8 +22,12 @@ use util::ArcLock;
 /// Sigmoid Activation Layer
 pub struct Sigmoid;
 
-impl<B: IBackend + conn::Sigmoid<f32>> ILayer<B> for Sigmoid {
+impl<B: IBackend + conn::Sigmoid<f32> + conn::SigmoidPointwise<f32>> ILayer<B> for Sigmoid {
     impl_ilayer_activation!();
+
+    fn compute_in_place(&self) -> bool {
+        true
+    }
 
     fn reshape(&mut self,
                backend: ::std::rc::Rc<B>,
@@ -33,23 +37,30 @@ impl<B: IBackend + conn::Sigmoid<f32>> ILayer<B> for Sigmoid {
                weights_gradient: &mut Vec<ArcLock<SharedTensor<f32>>>,
                output_data: &mut Vec<ArcLock<SharedTensor<f32>>>,
                output_gradient: &mut Vec<ArcLock<SharedTensor<f32>>>) {
-        let inp = input_data[0].read().unwrap();
-        output_data[0].write().unwrap().resize(inp.desc()).unwrap();
-        output_gradient[0].write().unwrap().resize(inp.desc()).unwrap();
+        if let Some(inp) = input_data.get(0) {
+            let read_inp = inp.read().unwrap();
+            let input_desc = read_inp.desc();
+            input_gradient[0].write().unwrap().resize(input_desc).unwrap();
+            output_data[0].write().unwrap().resize(input_desc).unwrap();
+            output_gradient[0].write().unwrap().resize(input_desc).unwrap();
+        }
     }
 }
 
-impl<B: IBackend + conn::Sigmoid<f32>> ComputeOutput<f32, B> for Sigmoid {
+impl<B: IBackend + conn::Sigmoid<f32> + conn::SigmoidPointwise<f32>> ComputeOutput<f32, B> for Sigmoid {
     fn compute_output(&self,
                       backend: &B,
                       _weights: &[&SharedTensor<f32>],
                       input_data: &[&SharedTensor<f32>],
                       output_data: &mut [&mut SharedTensor<f32>]) {
-        backend.sigmoid_plain(input_data[0], output_data[0]).unwrap();
+        match input_data.get(0) {
+            Some(input) => backend.sigmoid_plain(input, output_data[0]).unwrap(),
+            None => backend.sigmoid_pointwise_plain(output_data[0]).unwrap(),
+        }
     }
 }
 
-impl<B: IBackend + conn::Sigmoid<f32>> ComputeInputGradient<f32, B> for Sigmoid {
+impl<B: IBackend + conn::Sigmoid<f32> + conn::SigmoidPointwise<f32>> ComputeInputGradient<f32, B> for Sigmoid {
     fn compute_input_gradient(&self,
                               backend: &B,
                               weights_data: &[&SharedTensor<f32>],
@@ -57,8 +68,11 @@ impl<B: IBackend + conn::Sigmoid<f32>> ComputeInputGradient<f32, B> for Sigmoid 
                               output_gradients: &[&SharedTensor<f32>],
                               input_data: &[&SharedTensor<f32>],
                               input_gradients: &mut [&mut SharedTensor<f32>]) {
-        backend.sigmoid_grad_plain(output_data[0], output_gradients[0], input_data[0], input_gradients[0]).unwrap();
+        match output_data.get(0) {
+            Some(_) => backend.sigmoid_grad_plain(output_data[0], output_gradients[0], input_data[0], input_gradients[0]).unwrap(),
+            None => backend.sigmoid_pointwise_grad_plain(input_data[0], input_gradients[0]).unwrap(),
+        }
     }
 }
 
-impl<B: IBackend + conn::Sigmoid<f32>> ComputeParametersGradient<f32, B> for Sigmoid {}
+impl<B: IBackend + conn::Sigmoid<f32> + conn::SigmoidPointwise<f32>> ComputeParametersGradient<f32, B> for Sigmoid {}

--- a/src/layers/common/convolution.rs
+++ b/src/layers/common/convolution.rs
@@ -97,6 +97,10 @@ impl<B: conn::Convolution<f32>> FilterLayer for Convolution<B> {
 
 impl<B: IBackend + conn::Convolution<f32>> ILayer<B> for Convolution<B> {
     impl_ilayer_common!();
+    
+    fn auto_weight_blobs(&self) -> bool {
+        true
+    }
 
     fn reshape(&mut self,
                backend: ::std::rc::Rc<B>,

--- a/src/layers/common/convolution.rs
+++ b/src/layers/common/convolution.rs
@@ -97,7 +97,7 @@ impl<B: conn::Convolution<f32>> FilterLayer for Convolution<B> {
 
 impl<B: IBackend + conn::Convolution<f32>> ILayer<B> for Convolution<B> {
     impl_ilayer_common!();
-    
+
     fn auto_weight_blobs(&self) -> bool {
         true
     }

--- a/src/layers/common/linear.rs
+++ b/src/layers/common/linear.rs
@@ -69,6 +69,10 @@ impl Linear {
 impl<B: IBackend + LayerOps<f32>> ILayer<B> for Linear {
     impl_ilayer_common!();
 
+    fn auto_weight_blobs(&self) -> bool {
+        true
+    }
+
     fn init(&mut self, backend: Rc<B>) {
         let device = <B as IBackend>::device(&backend);
         let _ = self.one.add_device(device);

--- a/src/layers/utility/reshape.rs
+++ b/src/layers/utility/reshape.rs
@@ -53,7 +53,8 @@ impl<B: IBackend> ComputeOutput<f32, B> for Reshape {
                       backend: &B,
                       _weights: &[&SharedTensor<f32>],
                       input_data: &[&SharedTensor<f32>],
-                      output_data: &mut [&mut SharedTensor<f32>]) {}
+                      output_data: &mut [&mut SharedTensor<f32>]) {
+    }
 }
 
 impl<B: IBackend> ComputeInputGradient<f32, B> for Reshape {

--- a/src/util.rs
+++ b/src/util.rs
@@ -73,10 +73,18 @@ pub trait SolverOps<F> : Axpby<F> + Dot<F> + Copy<F> {}
 impl<T: Axpby<f32> + Dot<f32> + Copy<f32>> SolverOps<f32> for T {}
 
 /// Encapsulates all traits used in Layers.
-pub trait LayerOps<F> : conn::Convolution<F> + conn::Pooling<F> + conn::Relu<F> + conn::Sigmoid<F> + conn::Softmax<F> + conn::LogSoftmax<F>
-                             + Gemm<F> {}
+pub trait LayerOps<F> : conn::Convolution<F>
+                      + conn::Pooling<F>
+                      + conn::Relu<F> + conn::ReluPointwise<F>
+                      + conn::Sigmoid<F> + conn::SigmoidPointwise<F>
+                      + conn::Softmax<F> + conn::LogSoftmax<F>
+                      + Gemm<F> {}
 
-impl<T: conn::Convolution<f32> + conn::Pooling<f32> + conn::Relu<f32> + conn::Sigmoid<f32> + conn::Softmax<f32> + conn::LogSoftmax<f32>
+impl<T: conn::Convolution<f32>
+      + conn::Pooling<f32>
+      + conn::Relu<f32> + conn::ReluPointwise<f32>
+      + conn::Sigmoid<f32> + conn::SigmoidPointwise<f32>
+      + conn::Softmax<f32> + conn::LogSoftmax<f32>
       + Gemm<f32>> LayerOps<f32> for T {}
 
 // pub trait LayerOps<F> : conn::Relu<F> + conn::Sigmoid<F> + conn::Softmax<F> + conn::LogSoftmax<F>


### PR DESCRIPTION
Activations can now be calculated in-place, requiring less memory. To use it, the same blob name should be supplied as input and output to a activation layer.

Example:
```rust
// set up linear1 layer
let linear1_cfg = LinearConfig { output_size: 1568 };
let mut lnr1_cfg = LayerConfig::new("linear1", LayerType::Linear(linear1_cfg));
lnr1_cfg.add_input("data");
lnr1_cfg.add_output("linear1_out");
net_cfg.add_layer(lnr1_cfg);
// set up sigmoid layer
let mut sigmoid_cfg = LayerConfig::new("sigmoid", LayerType::Sigmoid);
sigmoid_cfg.add_input("linear1_out"); // same input and output
sigmoid_cfg.add_output("linear1_out"); // same input and output
net_cfg.add_layer(sigmoid_cfg);
```