### PR TITLE
Remove redundant .enumerate() calls and fix cargo bench compilation

### DIFF
--- a/benches/network_benches.rs
+++ b/benches/network_benches.rs
@@ -14,13 +14,7 @@ mod cuda {
     use std::sync::{Arc, RwLock};
     use leaf::layers::*;
     use leaf::layer::*;
-    use leaf::network::*;
     use std::rc::Rc;
-
-    #[cfg(feature = "native")]
-    fn native_backend() -> Rc<Backend<Native>> {
-        Rc::new(Backend::<Native>::default().unwrap())
-    }
 
     #[cfg(feature = "cuda")]
     fn cuda_backend() -> Rc<Backend<Cuda>> {
@@ -76,7 +70,7 @@ mod cuda {
     #[ignore]
     #[cfg(feature = "cuda")]
     fn bench_mnsit_forward_1(b: &mut Bencher) {
-        let mut cfg = NetworkConfig::default();
+        let mut cfg = SequentialConfig::default();
         // set up input
         cfg.add_input("in", &vec![1, 30, 30]);
         cfg.add_input("label", &vec![1, 1, 10]);
@@ -98,18 +92,14 @@ mod cuda {
         // cfg.add_layer(loss_cfg);
 
         let backend = cuda_backend();
-        let native_backend = native_backend();
-        let mut network = Network::from_config(backend.clone(), &cfg);
-        let loss = &mut 0f32;
+        let mut network = Layer::from_config(
+            backend.clone(), &LayerConfig::new("network", LayerType::Sequential(cfg)));
 
         let _ = timeit_loops!(10, {
             let inp = SharedTensor::<f32>::new(backend.device(), &vec![1, 30, 30]).unwrap();
-            let label = SharedTensor::<f32>::new(native_backend.device(), &vec![1, 1, 10]).unwrap();
-
             let inp_lock = Arc::new(RwLock::new(inp));
-            let label_lock = Arc::new(RwLock::new(label));
 
-            network.forward(&[inp_lock, label_lock], loss);
+            network.forward(&[inp_lock]);
         });
         // b.iter(|| {
         //     for _ in 0..1 {
@@ -128,7 +118,7 @@ mod cuda {
     // #[ignore]
     #[cfg(feature = "cuda")]
     fn alexnet_forward(b: &mut Bencher) {
-        let mut cfg = NetworkConfig::default();
+        let mut cfg = SequentialConfig::default();
         // Layer: data
         cfg.add_input("data", &vec![128, 3, 224, 224]);
         // Layer: conv1
@@ -265,15 +255,15 @@ mod cuda {
 
         let backend = cuda_backend();
         // let native_backend = native_backend();
-        let mut network = Network::from_config(backend.clone(), &cfg);
+        let mut network = Layer::from_config(
+            backend.clone(), &LayerConfig::new("network", LayerType::Sequential(cfg)));
 
         let func = || {
             let forward_time = timeit_loops!(1, {
-                let loss = &mut 0f32;
                 let inp = SharedTensor::<f32>::new(backend.device(), &vec![128, 3, 112, 112]).unwrap();
 
                 let inp_lock = Arc::new(RwLock::new(inp));
-                network.forward(&[inp_lock], loss);
+                network.forward(&[inp_lock]);
             });
             println!("Forward step: {}", forward_time);
         };
@@ -285,7 +275,7 @@ mod cuda {
     #[cfg(feature = "cuda")]
     fn small_alexnet_forward(b: &mut Bencher) {
         // let _ = env_logger::init();
-        let mut cfg = NetworkConfig::default();
+        let mut cfg = SequentialConfig::default();
         // Layer: data
         cfg.add_input("data", &vec![128, 3, 112, 112]);
         // Layer: conv1
@@ -422,14 +412,14 @@ mod cuda {
 
         let backend = cuda_backend();
         // let native_backend = native_backend();
-        let mut network = Network::from_config(backend.clone(), &cfg);
+        let mut network = Layer::from_config(
+            backend.clone(), &LayerConfig::new("network", LayerType::Sequential(cfg)));
 
         let mut func = || {
-            let loss = &mut 0f32;
             let inp = SharedTensor::<f32>::new(backend.device(), &vec![128, 3, 112, 112]).unwrap();
 
             let inp_lock = Arc::new(RwLock::new(inp));
-            network.forward(&[inp_lock], loss);
+            network.forward(&[inp_lock]);
         };
         { func(); bench_profile(b, func, 10); }
     }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -756,15 +756,15 @@ pub trait ILayer<B: IBackend> : ComputeOutput<f32, B> + ComputeInputGradient<f32
                output_data: &mut [ArcLock<SharedTensor<f32>>]) {
         // aquire all the locks
         let inp: Vec<_> = input_data.iter().map(|b| b.read().unwrap()).collect();
-        let input_data_: Vec<&SharedTensor<f32>> = inp.iter().enumerate().map(|(_, val)| &**val).collect();
+        let input_data_: Vec<&SharedTensor<f32>> = inp.iter().map(|val| &**val).collect();
 
         let wgts: Vec<_> = weights_data.iter().map(|w| w.read().unwrap()).collect();
-        let weights_data_: Vec<&SharedTensor<f32>> = wgts.iter().enumerate().map(|(_, val)| &**val).collect();
+        let weights_data_: Vec<&SharedTensor<f32>> = wgts.iter().map(|val| &**val).collect();
 
         let out_ref = output_data.iter().cloned().collect::<Vec<_>>();
         let mut out = &mut out_ref.iter().map(|b| b.write().unwrap()).collect::<Vec<_>>();
         let mut output_w = &mut out.iter_mut().map(|a| a).collect::<Vec<_>>();
-        let mut output_data_: Vec<&mut SharedTensor<f32>> = output_w.iter_mut().enumerate().map(|(_, val)| &mut ***val).collect();
+        let mut output_data_: Vec<&mut SharedTensor<f32>> = output_w.iter_mut().map(|val| &mut ***val).collect();
 
         self.compute_output(backend, &weights_data_, &input_data_, &mut output_data_);
     }
@@ -785,17 +785,17 @@ pub trait ILayer<B: IBackend> : ComputeOutput<f32, B> + ComputeInputGradient<f32
                 input_data: &[ArcLock<SharedTensor<f32>>],
                 input_gradients: &mut [ArcLock<SharedTensor<f32>>]) {
         let wgts_data: Vec<_> = weights_data.iter().map(|b| b.read().unwrap()).collect();
-        let weights_data_: Vec<&SharedTensor<f32>> = wgts_data.iter().enumerate().map(|(_, val)| &**val).collect();
+        let weights_data_: Vec<&SharedTensor<f32>> = wgts_data.iter().map(|val| &**val).collect();
         let out_data: Vec<_> = output_data.iter().map(|b| b.read().unwrap()).collect();
-        let output_data_: Vec<&SharedTensor<f32>> = out_data.iter().enumerate().map(|(_, val)| &**val).collect();
+        let output_data_: Vec<&SharedTensor<f32>> = out_data.iter().map(|val| &**val).collect();
         let out_gradient: Vec<_> = output_gradients.iter().map(|b| b.read().unwrap()).collect();
-        let output_gradients_: Vec<&SharedTensor<f32>> = out_gradient.iter().enumerate().map(|(_, val)| &**val).collect();
+        let output_gradients_: Vec<&SharedTensor<f32>> = out_gradient.iter().map(|val| &**val).collect();
         let inp_data: Vec<_> = input_data.iter().map(|b| b.read().unwrap()).collect();
-        let input_data_: Vec<&SharedTensor<f32>> = inp_data.iter().enumerate().map(|(_, val)| &**val).collect();
+        let input_data_: Vec<&SharedTensor<f32>> = inp_data.iter().map(|val| &**val).collect();
         let btm_gradient_ref = input_gradients.iter().cloned().collect::<Vec<_>>();
         let mut btm_gradient = &mut btm_gradient_ref.iter().map(|b| b.write().unwrap()).collect::<Vec<_>>();
         let mut input_gradient = &mut btm_gradient.iter_mut().map(|a| a).collect::<Vec<_>>();
-        let mut input_gradients_: Vec<&mut SharedTensor<f32>> = input_gradient.iter_mut().enumerate().map(|(_, val)| &mut ***val).collect();
+        let mut input_gradients_: Vec<&mut SharedTensor<f32>> = input_gradient.iter_mut().map(|val| &mut ***val).collect();
 
         self.compute_input_gradient(backend, &weights_data_, &output_data_, &output_gradients_, &input_data_, &mut input_gradients_);
     }
@@ -815,15 +815,15 @@ pub trait ILayer<B: IBackend> : ComputeOutput<f32, B> + ComputeInputGradient<f32
                 input_data: &[ArcLock<SharedTensor<f32>>],
                 weights_gradients: &mut [ArcLock<SharedTensor<f32>>]) {
         let out_data: Vec<_> = output_data.iter().map(|b| b.read().unwrap()).collect();
-        let output_data_: Vec<&SharedTensor<f32>> = out_data.iter().enumerate().map(|(_, val)| &**val).collect();
+        let output_data_: Vec<&SharedTensor<f32>> = out_data.iter().map(|val| &**val).collect();
         let out_gradients: Vec<_> = output_gradients.iter().map(|b| b.read().unwrap()).collect();
-        let output_gradients_: Vec<&SharedTensor<f32>> = out_gradients.iter().enumerate().map(|(_, val)| &**val).collect();
+        let output_gradients_: Vec<&SharedTensor<f32>> = out_gradients.iter().map(|val| &**val).collect();
         let inp_data: Vec<_> = input_data.iter().map(|b| b.read().unwrap()).collect();
-        let input_data_: Vec<&SharedTensor<f32>> = inp_data.iter().enumerate().map(|(_, val)| &**val).collect();
+        let input_data_: Vec<&SharedTensor<f32>> = inp_data.iter().map(|val| &**val).collect();
         let wgt_gradient_ref = weights_gradients.iter().cloned().collect::<Vec<_>>();
         let mut wgt_gradient = &mut wgt_gradient_ref.iter().map(|b| b.write().unwrap()).collect::<Vec<_>>();
         let mut weights_gradient = &mut wgt_gradient.iter_mut().map(|a| a).collect::<Vec<_>>();
-        let mut weights_gradients_: Vec<&mut SharedTensor<f32>> = weights_gradient.iter_mut().enumerate().map(|(_, val)| &mut ***val).collect();
+        let mut weights_gradients_: Vec<&mut SharedTensor<f32>> = weights_gradient.iter_mut().map(|val| &mut ***val).collect();
 
         self.compute_parameters_gradient(backend, &output_data_, &output_gradients_, &input_data_, &mut weights_gradients_);
     }


### PR DESCRIPTION
I've refactured and fixed some trivial things while reading the code.

`cargo bench` compiles but panics in runtime, I think it should be easy to fix but it looks like benches are deprecated.