### PR TITLE
perf/solver: don't zero fill weight gradients

### DIFF
--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -70,8 +70,6 @@ impl<SolverB: IBackend + SolverOps<f32> + 'static, B: IBackend + LayerOps<f32> +
 
     /// Train the network with one minibatch
     pub fn train_minibatch(&mut self, mb_data: ArcLock<SharedTensor<f32>>, mb_target: ArcLock<SharedTensor<f32>>) -> ArcLock<SharedTensor<f32>> {
-        self.net.clear_weights_gradients();
-
         // forward through network and classifier
         let network_out = self.net.forward(&[mb_data])[0].clone();
         let _ = self.objective.forward(&[network_out.clone(), mb_target]);


### PR DESCRIPTION
**Please verify this PR! I'm not completely sure that it's correct.**

Weight gradients aren't used before they are overwritten at backpropagation
step, so initialization is redundant.

If #89 is applied, this patch improves performance 30% on
`leaf-examples mnist`.