### PR TITLE
docs/readme: fix small typo in layers

### DIFF
--- a/doc/book/layers.html
+++ b/doc/book/layers.html
@@ -72,7 +72,7 @@
 <p><a href="./deep-learning-glossary.html#Layer">Layers</a> are the only building
 blocks in Leaf. As we will see later on, everything is a layer. Even when
 we construct <a href="./deep-learning-glossary.html#Network">networks</a>, we are still just
-working with layers composed of smalle layers. This makes the API clean and expressive.</p>
+working with layers composed of smaller layers. This makes the API clean and expressive.</p>
 <p>A layer is like a function: given an input it computes an output.
 It could be some mathematical expression, like Sigmoid, ReLU, or a non-mathematical instruction,
 like querying data from a database, logging data, or anything in between.


### PR DESCRIPTION
Fixes line 75: 'smalle' => 'smaller'. Thanks for providing excellent docs in book form!